### PR TITLE
[LinkNavigator-Migration] UserInfoSetupView

### DIFF
--- a/BBIP/BBIP.xcodeproj/project.pbxproj
+++ b/BBIP/BBIP.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		C6516F632CF60EDD00FCFAF2 /* Complete_CreateStudy.json in Resources */ = {isa = PBXBuildFile; fileRef = C6516F622CF60EDD00FCFAF2 /* Complete_CreateStudy.json */; };
 		C6516F652CF6129000FCFAF2 /* Complete_Attendance.json in Resources */ = {isa = PBXBuildFile; fileRef = C6516F642CF6129000FCFAF2 /* Complete_Attendance.json */; };
 		C6516F672CF61E5B00FCFAF2 /* Splash.json in Resources */ = {isa = PBXBuildFile; fileRef = C6516F662CF61E5B00FCFAF2 /* Splash.json */; };
+		C65D17B52E0ADDCA000F0966 /* UserInfoSetupRouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65D17B42E0ADDCA000F0966 /* UserInfoSetupRouteBuilder.swift */; };
 		C668E9C62C7AABA300298B52 /* TabViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C668E9C52C7AABA300298B52 /* TabViewHeaderView.swift */; };
 		C668E9C82C7AB0BE00298B52 /* UISActiveAreaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C668E9C72C7AB0BE00298B52 /* UISActiveAreaView.swift */; };
 		C668E9CA2C7ABC2D00298B52 /* AreaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C668E9C92C7ABC2D00298B52 /* AreaData.swift */; };
@@ -373,6 +374,7 @@
 		C6516F622CF60EDD00FCFAF2 /* Complete_CreateStudy.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Complete_CreateStudy.json; sourceTree = "<group>"; };
 		C6516F642CF6129000FCFAF2 /* Complete_Attendance.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Complete_Attendance.json; sourceTree = "<group>"; };
 		C6516F662CF61E5B00FCFAF2 /* Splash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Splash.json; sourceTree = "<group>"; };
+		C65D17B42E0ADDCA000F0966 /* UserInfoSetupRouteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSetupRouteBuilder.swift; sourceTree = "<group>"; };
 		C668E9C52C7AABA300298B52 /* TabViewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewHeaderView.swift; sourceTree = "<group>"; };
 		C668E9C72C7AB0BE00298B52 /* UISActiveAreaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISActiveAreaView.swift; sourceTree = "<group>"; };
 		C668E9C92C7ABC2D00298B52 /* AreaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaData.swift; sourceTree = "<group>"; };
@@ -1140,6 +1142,7 @@
 		C6A10ACE2C6C7CC4001AA74E /* UserInfoSetup */ = {
 			isa = PBXGroup;
 			children = (
+				C65D17B42E0ADDCA000F0966 /* UserInfoSetupRouteBuilder.swift */,
 				C6A10ACF2C6C7D5E001AA74E /* UserInfoSetupView.swift */,
 				C6A10AD32C6C8CCC001AA74E /* UserInfoSetupViewModel.swift */,
 				C6934BCD2C822269006AA652 /* UISInnerView */,
@@ -1690,6 +1693,7 @@
 				C6516ECD2CEB6C5900FCFAF2 /* CreateCodeOnboardingView.swift in Sources */,
 				C6F2DA1E2CAAE033002023B6 /* CommentVO.swift in Sources */,
 				C6FA55F32C919D2100E537D7 /* UpcommingScheduleVO.swift in Sources */,
+				C65D17B52E0ADDCA000F0966 /* UserInfoSetupRouteBuilder.swift in Sources */,
 				C6FA56062C956D3700E537D7 /* CalendarView.swift in Sources */,
 				C6F98F502CAA991200F0D8E8 /* GetArchivedFileInfoUseCase.swift in Sources */,
 				C6F7007E2C9EF58E000CCC80 /* RecentPostMapper.swift in Sources */,

--- a/BBIP/BBIP/App/InitialRouterView/AppLaunchFlowManager.swift
+++ b/BBIP/BBIP/App/InitialRouterView/AppLaunchFlowManager.swift
@@ -29,7 +29,7 @@ final class AppLaunchFlowManager: ObservableObject {
             if isLoggedIn == false {
                 self.navigator.replace(paths: [BBIPMatchPath.onboarding.capitalizedPath], items: [:], isAnimated: false)
             } else if isUserProfileSet == false {
-                self.navigator.replace(paths: [BBIPMatchPath.infoSetup.capitalizedPath], items: [:], isAnimated: false)
+                self.navigator.replace(paths: [BBIPMatchPath.userInfoSetup.capitalizedPath], items: [:], isAnimated: false)
             } else {
                 self.navigator.replace(paths: [BBIPMatchPath.home.capitalizedPath], items: [:], isAnimated: false)
             }

--- a/BBIP/BBIP/App/LinkNavigator/BBIPMatchPath.swift
+++ b/BBIP/BBIP/App/LinkNavigator/BBIPMatchPath.swift
@@ -8,14 +8,23 @@
 import Foundation
 
 enum BBIPMatchPath: String {
-    case initialRoute
     
-    case splash
-    case onboarding
-    case infoSetup
-    case startGuide
+    case initialRoute       // 앱 진입 분기점
+    
+    
+    case splash             // 스플래시 화면
+    case onboarding         // 온보딩 화면
+    case login              // Apple 로그인 화면
+    
+    
+    case userInfoSetup      // 유저 필수 정보 세팅
+    case startGuide         // 스터디 생성 또는 가입 유도 화면 (신규 유저 + 가입된 스터디 X)
+    
+    
     case home
+}
 
+extension BBIPMatchPath {
     var capitalizedPath: String {
         rawValue.prefix(1).uppercased() + rawValue.dropFirst()
     }

--- a/BBIP/BBIP/Core/Injection/DIContainerFactory.swift
+++ b/BBIP/BBIP/Core/Injection/DIContainerFactory.swift
@@ -68,13 +68,11 @@ extension Container {
 
     // MARK: - ViewModels
     var loginViewModel: Factory<LoginViewModel> {
-        Factory(self) { LoginViewModel() }
+        self { LoginViewModel() }
     }
 
     var userInfoSetupViewModel: Factory<UserInfoSetupViewModel> {
-        Factory(self) {
-            UserInfoSetupViewModel(createUserInfoUseCase: self.createUserInfoUseCase())
-        }
+        self { UserInfoSetupViewModel() }
     }
 }
 

--- a/BBIP/BBIP/Core/LegacyInjection/DIContainer.swift
+++ b/BBIP/BBIP/Core/LegacyInjection/DIContainer.swift
@@ -180,9 +180,9 @@ class DIContainer {
     //    }
     
     // UserInfoSetup
-    func makeUserInfoSetupViewModel() -> UserInfoSetupViewModel {
-        return UserInfoSetupViewModel(createUserInfoUseCase: createUserInfoUseCase)
-    }
+//    func makeUserInfoSetupViewModel() -> UserInfoSetupViewModel {
+//        return UserInfoSetupViewModel(createUserInfoUseCase: createUserInfoUseCase)
+//    }
     
     // UserHome
     func makeUserHomeViewModel() -> UserHomeViewModel {

--- a/BBIP/BBIP/Feature/Onboarding/OnboardingViewModel.swift
+++ b/BBIP/BBIP/Feature/Onboarding/OnboardingViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class OnboardingViewModel: ObservableObject {
+final class OnboardingViewModel: ObservableObject {
     @Published var onboardingContents: [OnboardingContent]
     @Published var showLoginView: Bool = false
     
@@ -15,5 +15,3 @@ class OnboardingViewModel: ObservableObject {
         self.onboardingContents = OnboardingContent.generate()
     }
 }
-
-

--- a/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupRouteBuilder.swift
+++ b/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupRouteBuilder.swift
@@ -1,0 +1,22 @@
+//
+//  UserInfoSetupRouteBuilder.swift
+//  BBIP
+//
+//  Created by 이건우 on 6/24/25.
+//
+
+import LinkNavigator
+import SwiftUI
+
+struct UserInfoSetupRouteBuilder: RouteBuilder {
+    var matchPath: String { BBIPMatchPath.userInfoSetup.capitalizedPath }
+    
+    var build: (LinkNavigatorType, [String: String], DependencyType) -> MatchingViewController? {
+        { navigator, items, dependency in
+            return WrappingController(matchPath: matchPath) {
+                UserInfoSetupView()
+            }
+            .defaultContext()
+        }
+    }
+}

--- a/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupView.swift
+++ b/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupView.swift
@@ -5,11 +5,12 @@
 //  Created by 이건우 on 8/14/24.
 //
 
+import Factory
 import SwiftUI
 import SwiftUIIntrospect
 
 struct UserInfoSetupView: View {
-    @StateObject private var userInfoSetupViewModel = DIContainer.shared.makeUserInfoSetupViewModel()
+    @StateObject private var userInfoSetupViewModel = Container.shared.userInfoSetupViewModel()
     @State private var selectedIndex: Int = 0
     
     private func buttonText() -> String {

--- a/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupViewModel.swift
+++ b/BBIP/BBIP/Feature/UserInfoSetup/UserInfoSetupViewModel.swift
@@ -8,18 +8,14 @@
 import Combine
 import Foundation
 import PhotosUI
+import Factory
 
-class UserInfoSetupViewModel: ObservableObject {
+final class UserInfoSetupViewModel: ObservableObject {
+    
+    @Injected(\.createUserInfoUseCase) private var createUserInfoUseCase
+    
     @Published var isLoading: Bool = false
-    private let createUserInfoUseCase: CreateUserInfoUseCaseProtocol
-    private var cancellables = Set<AnyCancellable>()
-    
-    init(createUserInfoUseCase: CreateUserInfoUseCaseProtocol) {
-        self.createUserInfoUseCase = createUserInfoUseCase
-        self.contentData = UserInfoSetupContent.generate()
-    }
-    
-    @Published var contentData: [UserInfoSetupContent]
+    @Published var contentData: [UserInfoSetupContent] = UserInfoSetupContent.generate()
     @Published var canGoNext: [Bool] = [
         false,  // 지역 설정
         false,  // 관심사 (스킵 가능)
@@ -28,7 +24,7 @@ class UserInfoSetupViewModel: ObservableObject {
         false   // 직업
     ]
     @Published var showCompleteView: Bool = false
-    
+    private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Active Area Setting View
     // 지역 재 선택시 기존의 데이터 리셋


### PR DESCRIPTION
## What is this PR? 👀
UserInfoSetupView LinkNavigator 적용
<br><br/>

## Changes 📃
- `MatchPath` 추가
  - 주석 정리 및 indent 리팩토링
- `RouteBuilder` 생성
- Di Factory 적용
  - 이전에 함께 파일럿 케이스로 적용했던 OnboardingView 관련 수정사항도 조금 포함되어 있습니다.
  - cb05279409f5880b99dfbfa3eb3c024be534e3d8 > `DIContainerFactory.swift`
<br><br/>

## Screenshot (optional) 📷
해당 없음.
<br><br/>

## Additional & Warning points (optional) 📌
1. LinkNavigator Migration 관련해서 더 좋은 방법이나 다른 의견 있으시면 멘션해서 바로 알려주세요!
> 없다면 해당 MR 기반으로 마이그레이션 진행 예정입니다.

2. 마이그레이션 진행하면서 ViewModel에 `final` 키워드 붙여주세요!
- 이외에도 제어 접근자, 주석, indent 수정과 같은 작은 리팩토링도 함께 진행해주시면 감사하겠습니다. ㅎㅎ

3. 따로 .push 처리가 PR에 포함되지 않은 이유는 아직 initialRoute 바운더리의 View이기 때문입니다.
> 주요 피쳐들은 `MainHomeView`를 기반으로 `.push` `.pop`되기 때문임.
- 이후에 저는 `LoginView` 진행 예정이며, @Choe-ju 주원님 가능하시다면 구조 분석 겸 MainHomeView쪽 마이그레이션 진행해보는 건 어떠신가요??
<br><br/>

## Test result 🧪
없음.
